### PR TITLE
Corrección de error en dependencia kivy-deps.sdl2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ GitPython==3.1.41
 idna==3.4
 itsdangerous==2.1.2
 Jinja2==3.1.3
-kivy-deps.sdl2==0.7.0
+kivy-deps.sdl2
 lief==0.14.0
 MarkupSafe==2.1.5
 netifaces==0.11.0


### PR DESCRIPTION
Gracias a @rmenor que informó sobre el error:
ERROR: Could not find a version that satisfies the requirement kivy-deps.sdl2==0.7.0 (from versions: none) ERROR: No matching distribution found for kivy-deps.sdl2==0.7.0

El error indicaba que no se podía encontrar una versión compatible con la dependencia kivy-deps.sdl2==0.7.0. Esto podría deberse a que no existe una versión específica de esa dependencia con el número de versión exacto que se estaba solicitando.